### PR TITLE
fixing typo in configure to allow it to see LAPACK

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -30113,7 +30113,7 @@ sci_defs_files="$sci_defs_files include/sci_defs/blas_testdefs.h"
 
 ##  --  search for lapack stuff  -----------------------------------------
 
-if test "$with_lapack" != "no" -a "$HAVE_LAPCK" != "yes"; then
+if test "$with_lapack" != "no" -a "$HAVE_LAPACK" != "yes"; then
 
   # if HAVE_LAPACK is yes at this point, then atlas/mkl has been found and we
   # don't want to check for it here.


### PR DESCRIPTION
This typo was preventing the configure to find and use LAPACK that's part of MKL.