### PR TITLE
Stable time step fix

### DIFF
--- a/src/CCA/Components/Wasatch/Expressions/CellReynoldsNumber.cc
+++ b/src/CCA/Components/Wasatch/Expressions/CellReynoldsNumber.cc
@@ -20,12 +20,12 @@
 
 template< typename VelT>
 CellReynoldsNumber<VelT>::
-CellReynoldsNumber(const Expr::Tag& velTag, const Expr::Tag& viscosityTag, const std::string& direction)
+CellReynoldsNumber(const Expr::Tag& rhovelTag, const Expr::Tag& viscosityTag, const std::string& direction)
 : Expr::Expression<SpatialOps::SVolField>(),
   h_(1.0),
   direction_(direction)
 {
-  vel_ = create_field_request<VelT>(velTag);
+  rhovel_ = create_field_request<VelT>(rhovelTag);
   visc_ = create_field_request<SVolField>(viscosityTag);
 }
 
@@ -75,7 +75,7 @@ evaluate()
   SVolField& cellReynolds = *results[0];
   SVolField& cellReynoldsSquared = *results[1];
   
-  cellReynolds <<=(*interpVelT2SVolOp_)( abs(vel_->field_ref()) ) * h_ / visc_->field_ref();
+  cellReynolds <<=(*interpVelT2SVolOp_)( abs(rhovel_->field_ref()) ) * h_ / visc_->field_ref();
   
   cellReynoldsSquared <<= pow(cellReynolds,2);
 }
@@ -84,11 +84,11 @@ evaluate()
 template< typename VelT>
 CellReynoldsNumber<VelT>::
 Builder::Builder( const Expr::TagList& resultTags,
-                 const Expr::Tag& velTag,
+                 const Expr::Tag& rhovelTag,
                  const Expr::Tag& viscosityTag,
                  const std::string direction)
 : ExpressionBuilder( resultTags ),
-velTag_( velTag ),
+rhovelTag_( rhovelTag ),
 viscosityTag_( viscosityTag ),
 direction_(direction)
 {}
@@ -99,7 +99,7 @@ Expr::ExpressionBase*
 CellReynoldsNumber<VelT>::
 Builder::build() const
 {
-  return new CellReynoldsNumber( velTag_, viscosityTag_, direction_ );
+  return new CellReynoldsNumber( rhovelTag_, viscosityTag_, direction_ );
 }
 
 //==========================================================================

--- a/src/CCA/Components/Wasatch/Expressions/CellReynoldsNumber.h
+++ b/src/CCA/Components/Wasatch/Expressions/CellReynoldsNumber.h
@@ -17,7 +17,7 @@ template< typename VelT >
 class CellReynoldsNumber
  : public Expr::Expression<SpatialOps::SVolField>
 {
-  DECLARE_FIELD(VelT, vel_)
+  DECLARE_FIELD(VelT, rhovel_)
   DECLARE_FIELD (SVolField, visc_)
   
   double h_;
@@ -34,7 +34,7 @@ class CellReynoldsNumber
   const GradYT* gradYOp_;
   const GradZT* gradZOp_;
 
-  CellReynoldsNumber( const Expr::Tag& velTag,
+  CellReynoldsNumber( const Expr::Tag& rhovelTag,
                       const Expr::Tag& viscosityTag,
                       const std::string& direction);
 public:
@@ -46,14 +46,14 @@ public:
      *  @param resultTag the tag for the value that this expression computes
      */
     Builder( const Expr::TagList& resultTags,
-             const Expr::Tag& velTag,
+             const Expr::Tag& rhovelTag,
              const Expr::Tag& viscosityTag,
              const std::string direction);
 
     Expr::ExpressionBase* build() const;
 
   private:
-    const Expr::Tag velTag_, viscosityTag_;
+    const Expr::Tag rhovelTag_, viscosityTag_;
     const std::string direction_;
   };
 

--- a/src/CCA/Components/Wasatch/Expressions/CourantNumber.h
+++ b/src/CCA/Components/Wasatch/Expressions/CourantNumber.h
@@ -18,8 +18,9 @@ class CourantNumber
  : public Expr::Expression<SpatialOps::SVolField>
 {
   typedef SVolField FieldT;
-  DECLARE_FIELD(VelT, vel_)
-  
+  DECLARE_FIELD(FieldT, rho_)
+  DECLARE_FIELD(VelT, rhovel_)
+
   typedef typename SpatialOps::SingleValueField TimeField;
   DECLARE_FIELD (TimeField, dt_)
   
@@ -37,7 +38,8 @@ class CourantNumber
   const GradYT* gradYOp_;
   const GradZT* gradZOp_;
 
-  CourantNumber(  const Expr::Tag& velTag,
+  CourantNumber(const Expr::Tag& rhoTag,
+                const Expr::Tag& rhovelTag,
                 const Expr::Tag& dtTag,
                 const std::string& direction);
 public:
@@ -49,14 +51,15 @@ public:
      *  @param resultTag the tag for the value that this expression computes
      */
     Builder( const Expr::Tag& resultTag,
-             const Expr::Tag& velTag,
+             const Expr::Tag& rhoTag,
+             const Expr::Tag& rhovelTag,
              const Expr::Tag& timeTag,
              const std::string direction);
 
     Expr::ExpressionBase* build() const;
 
   private:
-    const Expr::Tag velTag_, dtTag_;
+    const Expr::Tag rhoTag_, rhovelTag_, dtTag_;
     const std::string direction_;
   };
 

--- a/src/CCA/Components/Wasatch/Expressions/StableTimestepForEq.h
+++ b/src/CCA/Components/Wasatch/Expressions/StableTimestepForEq.h
@@ -19,10 +19,13 @@ class StableTimestepForEq
 {
   typedef SVolField FieldT;
   DECLARE_FIELDS(SVolField, rho_, visc_, csound_)
-  DECLARE_FIELD(Vel1T, u_)
-  DECLARE_FIELD(Vel2T, v_)
-  DECLARE_FIELD(Vel3T, w_)
-
+  DECLARE_FIELD(Vel1T, rhou_)
+  DECLARE_FIELD(Vel2T, rhov_)
+  DECLARE_FIELD(Vel3T, rhow_)
+  
+  typedef SpatialOps::SingleValueField TimeField;
+  DECLARE_FIELDS(TimeField, rkStage_)
+  
   double dx_, dy_, dz_;
   const bool doX_, doY_, doZ_, isCompressible_;
   const bool is3dconvdiff_;
@@ -45,9 +48,9 @@ class StableTimestepForEq
 
   StableTimestepForEq( const Expr::Tag& rhoTag,
               const Expr::Tag& viscTag,
-              const Expr::Tag& uTag,
-              const Expr::Tag& vTag,
-              const Expr::Tag& wTag,
+              const Expr::Tag& rhouTag,
+              const Expr::Tag& rhovTag,
+              const Expr::Tag& rhowTag,
               const Expr::Tag& csoundTag,
               const std::string timeIntegratorName);
 public:
@@ -61,16 +64,16 @@ public:
     Builder( const Expr::Tag& resultTag,
              const Expr::Tag& rhoTag,
              const Expr::Tag& viscTag,
-             const Expr::Tag& uTag,
-             const Expr::Tag& vTag,
-             const Expr::Tag& wTag,
+             const Expr::Tag& rhouTag,
+             const Expr::Tag& rhovTag,
+             const Expr::Tag& rhowTag,
              const Expr::Tag& csoundTag,
              const std::string timeIntegratorName);
 
     Expr::ExpressionBase* build() const;
 
   private:
-    const Expr::Tag rhoTag_, viscTag_, uTag_, vTag_, wTag_, csoundTag_;
+    const Expr::Tag rhoTag_, viscTag_, rhouTag_, rhovTag_, rhowTag_, csoundTag_;
     const std::string timeIntegratorName_;
   };
 

--- a/src/CCA/Components/Wasatch/Wasatch.cc
+++ b/src/CCA/Components/Wasatch/Wasatch.cc
@@ -47,7 +47,6 @@
 #include <CCA/Components/Models/Radiation/RMCRT/Ray.h>
 
 #include <CCA/Components/Wasatch/Operators/OperatorTypes.h>
-#include <CCA/Components/Wasatch/Expressions/StableTimestep.h>
 #include <CCA/Components/Wasatch/CoordinateHelper.h>
 #include <CCA/Components/Wasatch/DualTimeMatrixManager.h>
 


### PR DESCRIPTION
* Changed the dependency of the stable timestep equation from `Velocity STATE_NONE` to `Momentum STATE_NP1` + `density STATE_NONE` ( In the future, we need to change the `density` to `STATE_NP1` for  variable density flows)
* Changed the dependency of the CellReynoldsNumber expression to Momentum STATE_NP1 instead of Vel STATE_NONE, also changed the signature of the CellReynoldsNumber constructor and the corresponding variables from `velTag` to `rhovelTag` and 
* Changed the dependency of the CourrantNumber from `Velocity STATE_NONE` to `Momentum STATE_NP1` + `density STATE_NONE` ( In the future, we need to change the `density` to `STATE_NP1` for variable density flows)
* Changed the parseEquation.cc to accommodate all the above changes
* Cleaned the Wasatch.cc by removing unnecessary include